### PR TITLE
Pin 3rd-party actions to SHA1

### DIFF
--- a/.github/workflows/build-publish.yml
+++ b/.github/workflows/build-publish.yml
@@ -25,14 +25,14 @@ jobs:
           fetch-depth: 1
 
       - name: Docker login
-        uses: azure/docker-login@v1
+        uses: azure/docker-login@83efeb77770c98b620c73055fbb59b2847e17dc0 #v1
         with:
           login-server: quay.io
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_PASSWORD }}
 
       - name: Docker Buildx
-        uses: crazy-max/ghaction-docker-buildx@v3.3.0
+        uses: crazy-max/ghaction-docker-buildx@bb77f35f7a82f54fcda51000ea4e4467825014fd #v3.3.0
         with:
           buildx-version: v0.4.2
           qemu-version: 5.1.0-2

--- a/.github/workflows/pr-check.yaml
+++ b/.github/workflows/pr-check.yaml
@@ -20,7 +20,7 @@ jobs:
 
     steps:
     - name: Docker Buildx
-      uses: crazy-max/ghaction-docker-buildx@v3.3.0
+      uses: crazy-max/ghaction-docker-buildx@bb77f35f7a82f54fcda51000ea4e4467825014fd #v3.3.0
       with:
         buildx-version: v0.4.2
         qemu-version: 5.1.0-2


### PR DESCRIPTION
Hi!

Following the [GH Action Security Hardening](https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions) guide we should use the commit SHA instead of the `branch` or `tag` for any third-party untrusted action.

This PR was submitted by a script.
